### PR TITLE
0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # WooriAlim
 ## 경로 : /xe/modules/ggmailing/
+XE(XpressEngine) Module

--- a/conf/info.xml
+++ b/conf/info.xml
@@ -6,7 +6,7 @@
   <description xml:lang="ko">우리알림 모듈 입니다.</description>
   <description xml:lang="en">WooRi Notification Module</description>
   <description xml:lang="jp">WooRi Notification モジュ-ル</description>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
   <date>2014-4-8</date>
   <category>service</category>
   <author email_address="xeadmin@forppl.com" link="http://xeadmin.com">

--- a/conf/module.xml
+++ b/conf/module.xml
@@ -1,52 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <permissions>
-      <permission action="dispGgmailingAdminIndex" target="manager" />
-      <permission action="dispGgmailingAdminList" target="manager" />
-	  <permission action="dispGgmailingAdminSmsList" target="manager" />
-      <permission action="dispGgmailingAdminInsert" target="manager" />
-	  <permission action="dispGgmailingAdminSmsInsert" target="manager" />
-      <permission action="dispGgmailingAdminConfig" target="manager" />
-      <permission action="dispGgmailingAdminSend" target="manager" />
-	  <permission action="dispGgmailingAdminSmsSend" target="manager" />
-      <permission action="dispGgmailingAdminPreview" target="manager" />
-      <permission action="dispGgmailingAdminInsertmembers" target="manager" />
-	  <permission action="dispGgmailingAdminNotice" target="manager" />
+    <permission action="dispGgmailingAdminIndex" target="manager" />
+    <permission action="dispGgmailingAdminList" target="manager" />
+    <permission action="dispGgmailingAdminSmsList" target="manager" />
+    <permission action="dispGgmailingAdminInsert" target="manager" />
+    <permission action="dispGgmailingAdminSmsInsert" target="manager" />
+    <permission action="dispGgmailingAdminConfig" target="manager" />
+    <permission action="dispGgmailingAdminSend" target="manager" />
+    <permission action="dispGgmailingAdminSmsSend" target="manager" />
+    <permission action="dispGgmailingAdminPreview" target="manager" />
+    <permission action="dispGgmailingAdminInsertmembers" target="manager" />
+    <permission action="dispGgmailingAdminNotice" target="manager" />
+    <permission action="dispGgmailingAdminDonotsend" target="manager" />
 
-      <permission action="procGgmailingAdminSendMail" target="manager" />
-      <permission action="procGgmailingAdminModuleConfig" target="manager" />
-      <permission action="procGgmailingAdminInsert" target="manager" />
-      <permission action="procGgmailingAdminSmsInsert" target="manager" />
-      <permission action="procGgmailingAdminList" target="manager" />
-	  <permission action="procGgmailingAdminSmsList" target="manager" />
-      <permission action="procGgmailingAdminDel" target="manager" />
-      <permission action="procGgmailingAdminUpdate" target="manager" />
-      <permission action="procGgmailingAdminSmsUpdate" target="manager" />
-      <permission action="procGgmailingAdminSend" target="manager" />
-	  <permission action="procGgmailingAdminSmsSend" target="manager" />
-	  <permission action="procGgmailingAdminMemberInsert" target="manager" />
-	  <permission action="procGgmailingAdminMemberDelete" target="manager" />
-	  <permission action="procGgmailingAdminSendOk" target="manager" />
-	  <permission action="procGgmailingAdminSmsSendOk" target="manager" />
-	  <permission action="procGgmailingAdminAllSendOk" target="manager" />
-	  <permission action="procGgmailingAdminSmsAllSendOk" target="manager" />
-	  <permission action="procGgmailingAdminBoardmailingDelete" target="manager" />
-	  <permission action="procGgmailingAdminDBInsert" target="manager" />
-
+    <permission action="procGgmailingAdminSendMail" target="manager" />
+    <permission action="procGgmailingAdminModuleConfig" target="manager" />
+    <permission action="procGgmailingAdminInsert" target="manager" />
+    <permission action="procGgmailingAdminSmsInsert" target="manager" />
+    <permission action="procGgmailingAdminList" target="manager" />
+    <permission action="procGgmailingAdminSmsList" target="manager" />
+    <permission action="procGgmailingAdminDel" target="manager" />
+    <permission action="procGgmailingAdminUpdate" target="manager" />
+    <permission action="procGgmailingAdminSmsUpdate" target="manager" />
+    <permission action="procGgmailingAdminSend" target="manager" />
+    <permission action="procGgmailingAdminSmsSend" target="manager" />
+    <permission action="procGgmailingAdminMemberInsert" target="manager" />
+    <permission action="procGgmailingAdminMemberDelete" target="manager" />
+    <permission action="procGgmailingAdminSendOk" target="manager" />
+    <permission action="procGgmailingAdminSmsSendOk" target="manager" />
+    <permission action="procGgmailingAdminAllSendOk" target="manager" />
+    <permission action="procGgmailingAdminSmsAllSendOk" target="manager" />
+    <permission action="procGgmailingAdminBoardmailingDelete" target="manager" />
+    <permission action="procGgmailingAdminDBInsert" target="manager" />
+    <permission action="procGgmailingAdminDonotsendDelete" target="manager" />
+    
   </permissions>
   <actions>
     <action name="dispGgmailingAdminIndex" type="view" standalone="true" />
     <action name="dispGgmailingAdminList" type="view" standalone="true" />
-	<action name="dispGgmailingAdminSmsList" type="view" standalone="true" />
+	  <action name="dispGgmailingAdminSmsList" type="view" standalone="true" />
     <action name="dispGgmailingAdminInsert" type="view" standalone="true" />
-	<action name="dispGgmailingAdminSmsInsert" type="view" standalone="true" />
+	  <action name="dispGgmailingAdminSmsInsert" type="view" standalone="true" />
     <action name="dispGgmailingAdminConfig" type="view" standalone="true" />
     <action name="dispGgmailingAdminSend" type="view" standalone="true" />
-	<action name="dispGgmailingAdminSmsSend" type="view" standalone="true" />
+	  <action name="dispGgmailingAdminSmsSend" type="view" standalone="true" />
     <action name="dispGgmailingAdminPreview" type="view" standalone="true" />
     <action name="dispGgmailingAdminInsertmembers" type="view" standalone="true" />
-	<action name="dispGgmailingAdminBoardMailing" type="view" standalone="true" />
-	<action name="dispGgmailingAdminNotice" type="view" standalone="true" admin_index="true" menu_name="ggmailing" menu_index="true" />
+	  <action name="dispGgmailingAdminBoardMailing" type="view" standalone="true" />
+	  <action name="dispGgmailingAdminNotice" type="view" standalone="true" admin_index="true" menu_name="ggmailing" menu_index="true" />
+    <action name="dispGgmailingAdminDonotsend" type="view" standalone="true" />
    
     <action name="procGgmailingAdminSendMail" type="controller" standalone="true" />
     <action name="procGgmailingAdminModuleConfig" type="controller" standalone="true" />
@@ -58,30 +61,31 @@
     <action name="procGgmailingAdminUpdate" type="controller" standalone="true" />
     <action name="procGgmailingAdminSmsUpdate" type="controller" standalone="true" />
     <action name="procGgmailingAdminSend" type="controller" standalone="true" />
-	<action name="procGgmailingAdminSmsSend" type="controller" standalone="true" />
-	<action name="procGgmailingAdminMemberInsert" type="controller" standalone="true" />
-	<action name="procGgmailingAdminDBInsert" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminSmsSend" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminMemberInsert" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminDBInsert" type="controller" standalone="true" />
+    <action name="procGgmailingAdminDonotsendDelete" type="controller" standalone="true" />
 
     <action name="procGgmailingInsert" type="controller" standalone="true" />
     <action name="procGgmailingAdminMemberDelete" type="controller" standalone="true" />
-	<action name="procGgmailingAdminSendOk" type="controller" standalone="true" />
-	<action name="procGgmailingAdminSmsSendOk" type="controller" standalone="true" />
-	<action name="procGgmailingAdminAllSendOk" type="controller" standalone="true" />
-	<action name="procGgmailingAdminSmsAllSendOk" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminSendOk" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminSmsSendOk" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminAllSendOk" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminSmsAllSendOk" type="controller" standalone="true" />
 	
-	<action name="procGgmailingAdminBoardmailingDelete" type="controller" standalone="true" />
+	  <action name="procGgmailingAdminBoardmailingDelete" type="controller" standalone="true" />
 
-	<action name="dispGgmailingDonotsend" type="view" />
+	  <action name="dispGgmailingDonotsend" type="view" />
 
-	<action name="procGgmailingBoardSendOk" type="controller" />
-	<action name="procGgmailingXeSend" type="controller" />
+	  <action name="procGgmailingBoardSendOk" type="controller" />
+	  <action name="procGgmailingXeSend" type="controller" />
 	
   </actions>
   <menus>
-        <menu name="ggmailing">
-            <title xml:lang="en">Woori Notification</title>
-            <title xml:lang="ko">우리알림</title>
-            <title xml:lang="jp">Woori Notification</title>
-        </menu>
+    <menu name="ggmailing">
+        <title xml:lang="en">Woori Notification</title>
+        <title xml:lang="ko">우리알림</title>
+        <title xml:lang="jp">Woori Notification</title>
+    </menu>
   </menus>
 </module>

--- a/ggmailing.admin.controller.php
+++ b/ggmailing.admin.controller.php
@@ -179,7 +179,7 @@ class ggmailingAdminController extends ggmailing
 		//$authcheck = json_decode($curl);
 
 		$args->is_sendok = 'W';
-		if($response) executeQuery('ggmailing.updateGgmailingAdminSmsSend',$args);
+		if($authcheck) executeQuery('ggmailing.updateGgmailingAdminSmsSend',$args);
 
 	} //end function
 
@@ -297,7 +297,7 @@ class ggmailingAdminController extends ggmailing
 		//$authcheck = json_decode($curl);
 		
 		$args->is_sendok = 'W';
-		if($response) executeQuery('ggmailing.updateGgmailingAdminSend',$args);
+		executeQuery('ggmailing.updateGgmailingAdminSend',$args);
 		
 	} //end function
 
@@ -907,6 +907,18 @@ $args->co = '<br /><br /><div style="border:1px solid #ccc;padding:5px;">{nickna
 		executeQuery('ggmailing.deleteGgmailingBoardMember',$args);
 
 		$returnUrl = getNotEncodedUrl('', 'module', 'admin', 'act', 'dispGgmailingAdminBoardMailing');
+		//$this->setRedirectUrl($returnUrl);
+		header("Location:" . $returnUrl);
+
+	}
+
+	function procGgmailingAdminDonotsendDelete()
+	{
+		$args = Context::getRequestVars();
+
+		executeQuery('ggmailing.deleteGgmailingDonotsend',$args);
+
+		$returnUrl = getNotEncodedUrl('', 'module', 'admin', 'act', 'dispGgmailingAdminDonotsend');
 		//$this->setRedirectUrl($returnUrl);
 		header("Location:" . $returnUrl);
 

--- a/ggmailing.admin.controller.php
+++ b/ggmailing.admin.controller.php
@@ -14,6 +14,63 @@ class ggmailingAdminController extends ggmailing
 	{
 	}
 
+	function curl_request_async($url, $params, $type='POST', $output)  
+	{  
+	    foreach ($params as $key => &$val)  
+	    {  
+	        if (is_array($val))
+	        {  
+	        	$val = implode(',', $val);  
+	        }
+	        $post_params[] = $key.'='.urlencode($val);  
+	    }  
+	    $post_string = implode('&', $post_params);  
+	  
+	    $parts=parse_url($url);  
+	  
+	    if ($parts['scheme'] == 'http')  
+	    {  
+	        $fp = fsockopen($parts['host'], isset($parts['port'])?$parts['port']:80, $errno, $errstr, 30);  
+	    }  
+	    elseif ($parts['scheme'] == 'https')  
+	    {  
+	        $fp = fsockopen("ssl://" . $parts['host'], isset($parts['port'])?$parts['port']:443, $errno, $errstr, 30);  
+	    }  
+	  
+	    // Data goes in the path for a GET request  
+	    if('GET' == $type)
+	    {
+	    	$parts['path'] .= '?'.$post_string;  
+	    }
+	  
+	    $out = "$type ".$parts['path']." HTTP/1.1\r\n";  
+	    $out.= "Host: ".$parts['host']."\r\n";  
+	    $out.= "Content-Type: application/x-www-form-urlencoded\r\n";  
+	    $out.= "Content-Length: ".strlen($post_string)."\r\n";  
+	    $out.= "Connection: Close\r\n\r\n";  
+	    // Data goes in the request body for a POST request  
+	    if ('POST' == $type && isset($post_string))
+	    {
+	    	$out.= $post_string;  
+	    }
+	    fwrite($fp, $out);  
+	    if($output == 'json')
+	    {
+	    	// header 부분 걷어냄
+		    while (!feof($fp))
+		    {
+		        $buffer .= fread($fp,1024);
+		    }
+			if($buffer)
+			{
+				$pos = strpos($buffer, "\r\n\r\n");
+				$buffer = substr($buffer, $pos + 4);
+		    	return $buffer;
+		    }
+	    }
+	    fclose($fp);
+	} 
+
 	function procGgmailingAdminSmsAllSendOk()
 	{
 		$args = Context::getRequestVars();
@@ -117,18 +174,10 @@ class ggmailingAdminController extends ggmailing
 				"USE_PAGE" => $wwoutput->USE_PAGE,
 				"is_sendok" => $args->is_sendok
 			);
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL,$url);
-		curl_setopt($ch, CURLOPT_POST,1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS,$post_data);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		if($config->ggmailing_ssl == 'Y') {
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		}
-		$response = curl_exec($ch);
-		//$authcheck = json_decode($response);
-		curl_close($ch);
+		// 비동기
+		$curl = $this->curl_request_async($url, $post_data, $type='POST', $output='');
+		//$authcheck = json_decode($curl);
+
 		$args->is_sendok = 'W';
 		if($response) executeQuery('ggmailing.updateGgmailingAdminSmsSend',$args);
 
@@ -243,17 +292,9 @@ class ggmailingAdminController extends ggmailing
 				"type_donotsend" => $config->type_donotsend,
 				"is_sendok" => $args->is_sendok
 			);
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL,$url);
-		curl_setopt($ch, CURLOPT_POST,1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS,$post_data);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		if($config->ggmailing_ssl == 'Y') {
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		}
-		$response = curl_exec($ch);
-		curl_close($ch);
+		// 비동기
+		$curl = $this->curl_request_async($url, $post_data, $type='POST', $output='');
+		//$authcheck = json_decode($curl);
 		
 		$args->is_sendok = 'W';
 		if($response) executeQuery('ggmailing.updateGgmailingAdminSend',$args);

--- a/ggmailing.admin.view.php
+++ b/ggmailing.admin.view.php
@@ -32,41 +32,7 @@ class ggmailingAdminView extends ggmailing
 		$config = $oModuleModel->getModuleConfig('ggmailing');
 		$this->config = $config;
 		Context::set('config', $config);
-		
-		$dmn = getFullUrl('');
-		$dmn = parse_url($dmn);
-		$domain = substr($dmn['host'] . $dmn['path'], 0, -1);
-		$domain = str_replace('www.','',$domain);
-		
-		$ggmailing_serv_url = $config->ggmailing_serv_url;
-		if($config->ggmailing_ssl == 'N' || !$config->ggmailing_ssl) { $ggmailing_ssl = 'http://'; $ggmailing_ssl_port = ''; } elseif($config->ggmailing_ssl == 'Y') { $ggmailing_ssl = 'https://'; $ggmailing_ssl_port = ':' . $config->ggmailing_ssl_port; }
-		$url = $ggmailing_ssl . $ggmailing_serv_url . $ggmailing_ssl_port . '/index.php';
-		
-		$post_data = array(
-				'act' => 'dispWwapimanagerRequest',
-				'authkey' => $config->ggmailing_authkey,
-				'mid' => 'auth_woorimail',
-				'domain' => $domain,
-				'type' => 'ggmailing'
-		);
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL,$url);
-		curl_setopt($ch, CURLOPT_POST, true);
-		curl_setopt($ch, CURLOPT_POSTFIELDS,$post_data);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		if($config->ggmailing_ssl == 'Y') {
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		}
-		$response = curl_exec($ch);
-		$authcheck = json_decode($response);
-		$cinfo = curl_getinfo($ch);
-		$cerror = curl_error($ch);
-
-		if(!$authcheck->ggauth_check) $authcheck->ggauth_check = '서버점검중';
-		Context::set('authcheck',$authcheck);
-		curl_close($ch);
-
+	
 		$template_path = sprintf("%stpl/",$this->module_path);
 		$this->setTemplatePath($template_path);
 	}
@@ -104,43 +70,6 @@ class ggmailingAdminView extends ggmailing
 
 	function dispGgmailingAdminNotice() 
 	{
-		$oModuleModel = getModel('module');
-		$config = $oModuleModel->getModuleConfig('ggmailing');
-
-		$dmn = getFullUrl('');
-		$dmn = parse_url($dmn);
-		$domain = substr($dmn['host'] . $dmn['path'], 0, -1);
-		$domain = str_replace('www.','',$domain);
-		
-		$ggmailing_serv_url = $config->ggmailing_serv_url;
-		if($config->ggmailing_ssl == 'N' || !$config->ggmailing_ssl) { $ggmailing_ssl = 'http://'; $ggmailing_ssl_port = ''; } elseif($config->ggmailing_ssl == 'Y') { $ggmailing_ssl = 'https://'; $ggmailing_ssl_port = ':' . $config->ggmailing_ssl_port; }
-		$url = $ggmailing_ssl . $ggmailing_serv_url . $ggmailing_ssl_port . '/index.php';
-		$post_data = array(
-				'act' => 'dispWwapimanagerRequest',
-				'authkey' => $config->ggmailing_authkey,
-				'mid' => 'auth_woorimail',
-				'domain' => $domain,
-				'type' => 'ggmailing',
-				'notice_mid' => 'notice' // 공지를 mid 값으로 호출
-		);
-		$ch = curl_init();
-		curl_setopt($ch, CURLOPT_URL,$url);
-		curl_setopt($ch, CURLOPT_POST,1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS,$post_data);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		if($config->ggmailing_ssl == 'Y') {
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		}
-		$response = curl_exec($ch);
-		$authcheck = json_decode($response);
-
-		$notice = $authcheck;
-		$notice->url = $url;
-		$notice->mid = $post_data['notice_mid'];
-		Context::set('authcheck',$authcheck);
-		curl_close($ch);
-		Context::set('notice',$notice);
 		$this->setTemplateFile('notice');
 	}
 

--- a/ggmailing.admin.view.php
+++ b/ggmailing.admin.view.php
@@ -37,6 +37,32 @@ class ggmailingAdminView extends ggmailing
 		$this->setTemplatePath($template_path);
 	}
 
+	function dispGgmailingAdminDonotsend()
+	{
+		$args = Context::getRequestVars();
+		if(!$args->page) $args->page = '1';
+		Context::set('args',$args);
+		
+		if($args->search_type=='ggmailing_email') {
+			$args->ggmailing_email = $args->search_keyword;
+		} elseif($args->search_type=='ggmailing_nickname') {
+			$args->ggmailing_nickname = $args->search_keyword;
+		} elseif($args->search_type=='ggmailing_member_srl') {
+			$args->ggmailing_member_srl = $args->search_keyword;
+		}
+
+		$output = executeQueryArray('ggmailing.getDonotsendList',$args);
+		if(!$output->toBool()) return $output;
+
+		Context::set('ds_info',$output->data);
+		Context::set('total_count', $output->total_count);
+		Context::set('total_page', $output->total_page);
+		Context::set('page', $output->page);
+		Context::set('page_navigation', $output->page_navigation);
+
+		$this->setTemplateFile('donotsend_list');
+	}
+
 	function dispGgmailingAdminBoardMailing() 
 	{
 		$args = Context::getRequestVars();

--- a/ggmailing.class.php
+++ b/ggmailing.class.php
@@ -15,6 +15,7 @@ class ggmailing extends ModuleObject {
 		$oModuleController->insertModule($args);
 		$oModuleController->insertActionForward('ggmailing', 'view', 'dispGgmailingAdminIndex');
 		$oModuleController->insertTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after');
+		$oModuleController->insertTrigger('comment.insertComment','ggmailing','controller','triggerWard','after');
 		$oModuleController->insertTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after');
 		return new Object();
 	}
@@ -24,6 +25,7 @@ class ggmailing extends ModuleObject {
 		$act = $oModuleModel->getActionForward('dispGgmailingAdminIndex');
 		if(!$act) return true;
 		if(!$oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after')) return true;
+		if(!$oModuleModel->getTrigger('comment.insertComment','ggmailing','controller','triggerWard','after')) return true;
 		if(!$oModuleModel->getTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after')) return true;
 		return false;
 	}
@@ -33,6 +35,9 @@ class ggmailing extends ModuleObject {
 		$oModuleController = &getController('module');
 		if(!$oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after')) {
 			$oModuleController->insertTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after');
+		}
+		if(!$oModuleModel->getTrigger('comment.insertComment','ggmailing','controller','triggerWard','after')) {
+			$oModuleController->insertTrigger('comment.insertComment','ggmailing','controller','triggerWard','after');
 		}
 		if(!$oModuleModel->getTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after')) {
 			$oModuleController->insertTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after');
@@ -47,6 +52,9 @@ class ggmailing extends ModuleObject {
 
 		if($oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after')) {
 			$oModuleController->deleteTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after');
+		}
+		if($oModuleModel->getTrigger('comment.insertComment','ggmailing','controller','triggerWard','after')) {
+			$oModuleController->deleteTrigger('comment.insertComment','ggmailing','controller','triggerWard','after');
 		}
 		if($oModuleModel->getTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after')) {
 			$oModuleController->deleteTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after');

--- a/ggmailing.class.php
+++ b/ggmailing.class.php
@@ -14,7 +14,7 @@ class ggmailing extends ModuleObject {
 		$args->module = 'ggmailing';
 		$oModuleController->insertModule($args);
 		$oModuleController->insertActionForward('ggmailing', 'view', 'dispGgmailingAdminIndex');
-		$oModuleController->insertTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after');
+		$oModuleController->insertTrigger('document.insertDocument','ggmailing','controller','triggerBoardmailing','after');
 		$oModuleController->insertTrigger('comment.insertComment','ggmailing','controller','triggerWard','after');
 		$oModuleController->insertTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after');
 		return new Object();
@@ -24,7 +24,7 @@ class ggmailing extends ModuleObject {
 		$oModuleModel = &getModel('module');
 		$act = $oModuleModel->getActionForward('dispGgmailingAdminIndex');
 		if(!$act) return true;
-		if(!$oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after')) return true;
+		if(!$oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerBoardmailing','after')) return true;
 		if(!$oModuleModel->getTrigger('comment.insertComment','ggmailing','controller','triggerWard','after')) return true;
 		if(!$oModuleModel->getTrigger('ncenterlite._insertNotify','ggmailing','controller','triggerNotiliteGgmailing','after')) return true;
 		return false;
@@ -33,8 +33,8 @@ class ggmailing extends ModuleObject {
 	function moduleUpdate() {
 		$oModuleModel = &getModel('module');
 		$oModuleController = &getController('module');
-		if(!$oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after')) {
-			$oModuleController->insertTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after');
+		if(!$oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerBoardmailing','after')) {
+			$oModuleController->insertTrigger('document.insertDocument','ggmailing','controller','triggerBoardmailing','after');
 		}
 		if(!$oModuleModel->getTrigger('comment.insertComment','ggmailing','controller','triggerWard','after')) {
 			$oModuleController->insertTrigger('comment.insertComment','ggmailing','controller','triggerWard','after');
@@ -50,8 +50,8 @@ class ggmailing extends ModuleObject {
 		$oModuleModel = &getModel('module');
 		$oModuleController = &getController('module');
 
-		if($oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after')) {
-			$oModuleController->deleteTrigger('document.insertDocument','ggmailing','controller','triggerInsertGgmailing','after');
+		if($oModuleModel->getTrigger('document.insertDocument','ggmailing','controller','triggerBoardmailing','after')) {
+			$oModuleController->deleteTrigger('document.insertDocument','ggmailing','controller','triggerBoardmailing','after');
 		}
 		if($oModuleModel->getTrigger('comment.insertComment','ggmailing','controller','triggerWard','after')) {
 			$oModuleController->deleteTrigger('comment.insertComment','ggmailing','controller','triggerWard','after');

--- a/ggmailing.controller.php
+++ b/ggmailing.controller.php
@@ -77,6 +77,10 @@ class ggmailingController extends ggmailing
 		// 와드 사용여부 체크
 		if(!$config->type_ward || $config->type_ward == 'F') return false;
 
+		// mid 가 등록되어 있지 않으면 return false
+		$_ward_mid = explode(',',$config->ward_mid);
+		if(in_array($obj->mid,$_ward_mid) == false) return false;
+
 		$num = 2000;
 		$obj->is_sendok = 'D';
 		$args = new stdClass();
@@ -137,6 +141,11 @@ class ggmailingController extends ggmailing
 		// 게시판 메일링 사용 여부 체크
 		if(!$config->type_board_mailing || $config->type_board_mailing == 'F') return false;
 
+		// mid 가 등록되어 있지 않으면 return false
+		$_newsletter_mid = explode(',',$config->newsletter_mid);
+		$_boardmailing_mid = explode(',',$config->boardmailing_mid);
+		if(in_array($obj->mid,$_newsletter_mid) == false && in_array($obj->mid,$_boardmailing_mid) == false) return false;
+
 		$num = 2000;
 		$obj->is_sendok = 'M';
 		$args = new stdClass();
@@ -147,7 +156,6 @@ class ggmailingController extends ggmailing
 
 		if($output->data) {
 			// 뉴스레터인 경우
-			$_newsletter_mid = explode(',',$config->newsletter_mid);
 			if(in_array($obj->mid,$_newsletter_mid)) {
 				$obj->sender_nickname = $obj->nick_name ? $obj->nick_name : $config->ggmailing_serv_url;
 				$obj->sender_email = 'NOREPLY@woorimail.com';

--- a/lang/en.lang.php
+++ b/lang/en.lang.php
@@ -2,7 +2,7 @@
 // normal
 $lang->donotsendlist = '수신거부 관리';
 $lang->configure = '설정';
-$lang->boardmailing = '게시판 메일링/댓글알림 관리';
+$lang->boardmailing = '게시판 메일링/댓글알림/뉴스레터 관리';
 $lang->manual = '사용자 가이드';
 $lang->insertmembers = '외부회원 등록 및 관리';
 $lang->regdate = '등록일';
@@ -80,9 +80,11 @@ $lang->manual_changestr = '치환변수';
 $lang->manual_changestr_content = '제목과 내용등록 시 {nickname},{email} 치환변수를 사용하면<br />
 받는회원 닉네임과 이메일주소가 자동으로 삽입됩니다.<br />
 치환변수를 하나의 단어로 간주하고 html을 적용할 수 있습니다.<br />';
-$lang->manual_boardmailing = '게시판 메일링/댓글알 관리';
+$lang->manual_boardmailing = '게시판 메일링/댓글알림/뉴스레터 관리';
 $lang->manual_boardmailing_content = '<a href=http://www.xpressengine.com/index.php?mid=download&package_id=22753306 target=_blank>게시판 메일링 위젯(GG Board Mailing Widget)</a> 을 이용하여 게시판 메일링을 구현할 수 있습니다.<br />
-게시판별 메일링/댓글알림 가입 회원을 관리합니다.';
+게시판 댓글알림 위젯(GG Ward Widget) 을 이용하여 게시판 댓글알림을 구현할 수 있습니다.<br />
+뉴스레터 위젯(GG Newsletter Widget) 을 이용하여 뉴스레터 메일링을 구현할 수 있습니다.<br />
+게시판별 메일링/댓글알림/뉴스레터 가입 회원을 관리합니다.';
 
 // list
 $lang->send_to_all = '전체보내기';

--- a/lang/en.lang.php
+++ b/lang/en.lang.php
@@ -1,7 +1,7 @@
 <?php
 // normal
 $lang->configure = '설정';
-$lang->boardmailing = '게시판 메일링 관리';
+$lang->boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual = '사용자 가이드';
 $lang->insertmembers = '외부회원 등록 및 관리';
 $lang->regdate = '등록일';
@@ -40,7 +40,7 @@ $lang->no_member = '메일을 발송할 회원이 없습니다.';
 $lang->save_ok = '저장되었습니다.';
 
 // header
-$lang->mailing = '우리알림';
+$lang->woorialim = '우리알림';
 $lang->mailing_status = '우리메일 서버 상황 및 나의 포인트';
 $lang->authcheck = '통신상태';
 $lang->paymail_ready = '유료메일 대기열';
@@ -52,7 +52,7 @@ $lang->pay_point = '유료 포인트';
 $lang->refresh = '상태 재확인';
 
 // index
-$lang->about_mailing = '1. 회원 가입시 이메일 주소가 정확하지 않으면 이메일이 도착하지 않습니다.
+$lang->about_woorialim = '1. 회원 가입시 이메일 주소가 정확하지 않으면 이메일이 도착하지 않습니다.
 2. 웹서버에 메일서버가 작동하지 않고 있어도 우리메일서버를 통해 메일이 전송됩니다.
 3. 첨부파일은 지원하지 않으며 본문에 링크를 첨부해서 메일 보내시기 바랍니다.(대량 메일 특성상 트래픽 문제가 발생할 수 있으니 웹호스팅 유저는 주의 바랍니다.) - 단독형
 4. 프로모션 포인트 > 무료 포인트 > 기타 포인트 > 유료 포인트 순으로 차감됩니다.
@@ -82,9 +82,9 @@ $lang->manual_changestr = '치환변수';
 $lang->manual_changestr_content = '제목과 내용등록 시 {nickname},{email} 치환변수를 사용하면<br />
 받는회원 닉네임과 이메일주소가 자동으로 삽입됩니다.<br />
 치환변수를 하나의 단어로 간주하고 html을 적용할 수 있습니다.<br />';
-$lang->manual_boardmailing = '게시판 메일링 관리';
+$lang->manual_boardmailing = '게시판 메일링/댓글알 관리';
 $lang->manual_boardmailing_content = '<a href=http://www.xpressengine.com/index.php?mid=download&package_id=22753306 target=_blank>게시판 메일링 위젯(GG Board Mailing Widget)</a> 을 이용하여 게시판 메일링을 구현할 수 있습니다.<br />
-게시판별 메일링 가입 회원을 관리합니다.';
+게시판별 메일링/댓글알림 가입 회원을 관리합니다.';
 
 // list
 $lang->send_to_all = '전체보내기';

--- a/lang/en.lang.php
+++ b/lang/en.lang.php
@@ -1,5 +1,6 @@
 <?php
 // normal
+$lang->donotsendlist = '수신거부 관리';
 $lang->configure = '설정';
 $lang->boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual = '사용자 가이드';
@@ -17,9 +18,6 @@ $lang->sender_email = '발송자 이메일';
 $lang->receive_email = '수신이메일';
 $lang->receive_nickname = '수신닉네임';
 $lang->wantdel = '삭제하시겠습니까?';
-
-// baordmailing
-
 
 // config
 $lang->warning = '우리알림 모듈은 포피플이 개발하고 배포하는 대량메일 솔루션 입니다.<br />

--- a/lang/jp.lang.php
+++ b/lang/jp.lang.php
@@ -1,5 +1,6 @@
 <?php
 // normal
+$lang->donotsendlist = '수신거부 관리';
 $lang->configure = '設定';
 $lang->boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual = '사용자 가이드';

--- a/lang/jp.lang.php
+++ b/lang/jp.lang.php
@@ -1,7 +1,7 @@
 <?php
 // normal
 $lang->configure = '設定';
-$lang->boardmailing = '게시판 메일링 관리';
+$lang->boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual = '사용자 가이드';
 $lang->insertmembers = '외부회원 등록 및 관리';
 $lang->regdate = '登録日';
@@ -40,7 +40,7 @@ $lang->no_member = 'メールを送信する会員がいません。';
 $lang->save_ok = '保存しました。';
 
 // header
-$lang->mailing = '우리알림';
+$lang->woorialim = '우리알림';
 $lang->mailing_status = '우리메일 서버 상황 및 나의 포인트';
 $lang->authcheck = '통신상태';
 $lang->paymail_ready = '유료메일 대기열';
@@ -52,7 +52,7 @@ $lang->pay_point = '유료 포인트';
 $lang->refresh = '상태 재확인';
 
 // index
-$lang->about_mailing = '1. 회원 가입시 이메일 주소가 정확하지 않으면 이메일이 도착하지 않습니다.
+$lang->about_woorialim = '1. 회원 가입시 이메일 주소가 정확하지 않으면 이메일이 도착하지 않습니다.
 2. 웹서버에 메일서버가 작동하지 않고 있어도 우리메일서버를 통해 메일이 전송됩니다.
 3. 첨부파일은 지원하지 않으며 본문에 링크를 첨부해서 메일 보내시기 바랍니다.(대량 메일 특성상 트래픽 문제가 발생할 수 있으니 웹호스팅 유저는 주의 바랍니다.) - 단독형
 4. 프로모션 포인트 > 무료 포인트 > 기타 포인트 > 유료 포인트 순으로 차감됩니다.
@@ -84,9 +84,10 @@ $lang->manual_changestr = '置換変数';
 $lang->manual_changestr_content = '제목과 내용등록 시 {nickname},{email} 치환변수를 사용하면<br />
 받는회원 닉네임과 이메일주소가 자동으로 삽입됩니다.<br />
 치환변수를 하나의 단어로 간주하고 html을 적용할 수 있습니다.<br />';
-$lang->manual_boardmailing = '게시판 메일링 관리';
+$lang->manual_boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual_boardmailing_content = '<a href=http://www.xpressengine.com/index.php?mid=download&package_id=22753306 target=_blank>게시판 메일링 위젯(GG Board Mailing Widget)</a> 을 이용하여 게시판 메일링을 구현할 수 있습니다.<br />
-게시판별 메일링 가입 회원을 관리합니다.';
+게시판 댓글알림 위젯(GG Ward Widget) 을 이용하여 게시판 댓글알림을 구현할 수 있습니다.<br />
+게시판별 메일링/댓글알림 가입 회원을 관리합니다.';
 
 // list
 $lang->send_to_all = '全送る';

--- a/lang/jp.lang.php
+++ b/lang/jp.lang.php
@@ -2,7 +2,7 @@
 // normal
 $lang->donotsendlist = '수신거부 관리';
 $lang->configure = '設定';
-$lang->boardmailing = '게시판 메일링/댓글알림 관리';
+$lang->boardmailing = '게시판 메일링/댓글알림/뉴스레터 관리';
 $lang->manual = '사용자 가이드';
 $lang->insertmembers = '외부회원 등록 및 관리';
 $lang->regdate = '登録日';
@@ -85,10 +85,11 @@ $lang->manual_changestr = '置換変数';
 $lang->manual_changestr_content = '제목과 내용등록 시 {nickname},{email} 치환변수를 사용하면<br />
 받는회원 닉네임과 이메일주소가 자동으로 삽입됩니다.<br />
 치환변수를 하나의 단어로 간주하고 html을 적용할 수 있습니다.<br />';
-$lang->manual_boardmailing = '게시판 메일링/댓글알림 관리';
+$lang->manual_boardmailing = '게시판 메일링/댓글알림/뉴스레터 관리';
 $lang->manual_boardmailing_content = '<a href=http://www.xpressengine.com/index.php?mid=download&package_id=22753306 target=_blank>게시판 메일링 위젯(GG Board Mailing Widget)</a> 을 이용하여 게시판 메일링을 구현할 수 있습니다.<br />
 게시판 댓글알림 위젯(GG Ward Widget) 을 이용하여 게시판 댓글알림을 구현할 수 있습니다.<br />
-게시판별 메일링/댓글알림 가입 회원을 관리합니다.';
+뉴스레터 위젯(GG Newsletter Widget) 을 이용하여 뉴스레터 메일링을 구현할 수 있습니다.<br />
+게시판별 메일링/댓글알림/뉴스레터 가입 회원을 관리합니다.';
 
 // list
 $lang->send_to_all = '全送る';

--- a/lang/ko.lang.php
+++ b/lang/ko.lang.php
@@ -1,5 +1,6 @@
 <?php
 // normal
+$lang->donotsendlist = '수신거부 관리';
 $lang->configure = '설정';
 $lang->boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual = '사용자 가이드';

--- a/lang/ko.lang.php
+++ b/lang/ko.lang.php
@@ -2,7 +2,7 @@
 // normal
 $lang->donotsendlist = '수신거부 관리';
 $lang->configure = '설정';
-$lang->boardmailing = '게시판 메일링/댓글알림 관리';
+$lang->boardmailing = '게시판 메일링/댓글알림/뉴스레터 관리';
 $lang->manual = '사용자 가이드';
 $lang->insertmembers = '외부회원 등록 및 관리';
 $lang->regdate = '등록일';
@@ -83,10 +83,11 @@ $lang->manual_changestr = '치환변수';
 $lang->manual_changestr_content = '제목과 내용등록 시 {nickname},{email} 치환변수를 사용하면<br />
 받는회원 닉네임과 이메일주소가 자동으로 삽입됩니다.<br />
 치환변수를 하나의 단어로 간주하고 html을 적용할 수 있습니다.<br />';
-$lang->manual_boardmailing = '게시판 메일링/댓글알림 관리';
+$lang->manual_boardmailing = '게시판 메일링/댓글알림/뉴스레터 관리';
 $lang->manual_boardmailing_content = '<a href=http://www.xpressengine.com/index.php?mid=download&package_id=22753306 target=_blank>게시판 메일링 위젯(GG Board Mailing Widget)</a> 을 이용하여 게시판 메일링을 구현할 수 있습니다.<br />
 게시판 댓글알림 위젯(GG Ward Widget) 을 이용하여 게시판 댓글알림을 구현할 수 있습니다.<br />
-게시판별 메일링/댓글알림 가입 회원을 관리합니다.';
+뉴스레터 위젯(GG Newsletter Widget) 을 이용하여 뉴스레터 메일링을 구현할 수 있습니다.<br />
+게시판별 메일링/댓글알림/뉴스레터 가입 회원을 관리합니다.';
 
 // list
 $lang->send_to_all = '전체보내기';

--- a/lang/ko.lang.php
+++ b/lang/ko.lang.php
@@ -1,7 +1,7 @@
 <?php
 // normal
 $lang->configure = '설정';
-$lang->boardmailing = '게시판 메일링 관리';
+$lang->boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual = '사용자 가이드';
 $lang->insertmembers = '외부회원 등록 및 관리';
 $lang->regdate = '등록일';
@@ -40,7 +40,7 @@ $lang->no_member = '메일을 발송할 회원이 없습니다.';
 $lang->save_ok = '저장되었습니다.';
 
 // header
-$lang->mailing = '우리알림';
+$lang->woorialim = '우리알림';
 $lang->mailing_status = '우리메일 서버 상황 및 나의 포인트';
 $lang->authcheck = '통신상태';
 $lang->paymail_ready = '유료메일 대기열';
@@ -52,7 +52,7 @@ $lang->pay_point = '유료 포인트';
 $lang->refresh = '상태 재확인';
 
 // index
-$lang->about_mailing = '1. 회원 가입시 이메일 주소가 정확하지 않으면 이메일이 도착하지 않습니다.
+$lang->about_woorialim = '1. 회원 가입시 이메일 주소가 정확하지 않으면 이메일이 도착하지 않습니다.
 2. 웹서버에 메일서버가 작동하지 않고 있어도 우리메일서버를 통해 메일이 전송됩니다.
 3. 첨부파일은 지원하지 않으며 본문에 링크를 첨부해서 메일 보내시기 바랍니다.(대량 메일 특성상 트래픽 문제가 발생할 수 있으니 웹호스팅 유저는 주의 바랍니다.) - 단독형
 4. 프로모션 포인트 > 무료 포인트 > 기타 포인트 > 유료 포인트 순으로 차감됩니다.
@@ -82,9 +82,10 @@ $lang->manual_changestr = '치환변수';
 $lang->manual_changestr_content = '제목과 내용등록 시 {nickname},{email} 치환변수를 사용하면<br />
 받는회원 닉네임과 이메일주소가 자동으로 삽입됩니다.<br />
 치환변수를 하나의 단어로 간주하고 html을 적용할 수 있습니다.<br />';
-$lang->manual_boardmailing = '게시판 메일링 관리';
+$lang->manual_boardmailing = '게시판 메일링/댓글알림 관리';
 $lang->manual_boardmailing_content = '<a href=http://www.xpressengine.com/index.php?mid=download&package_id=22753306 target=_blank>게시판 메일링 위젯(GG Board Mailing Widget)</a> 을 이용하여 게시판 메일링을 구현할 수 있습니다.<br />
-게시판별 메일링 가입 회원을 관리합니다.';
+게시판 댓글알림 위젯(GG Ward Widget) 을 이용하여 게시판 댓글알림을 구현할 수 있습니다.<br />
+게시판별 메일링/댓글알림 가입 회원을 관리합니다.';
 
 // list
 $lang->send_to_all = '전체보내기';

--- a/queries/deleteGgmailingBoardMember.xml
+++ b/queries/deleteGgmailingBoardMember.xml
@@ -2,10 +2,7 @@
     <tables>
         <table name="ggmailing_boards" />
     </tables>
-    <columns>
-    </columns>   
     <conditions>
-        <condition operation="equal" column="ggmailing_member_srl" var="ggmailing_member_srl" />
-		<condition operation="equal" column="ggmailing_module_srl" var="ggmailing_module_srl" pipe="and" />
+        <condition operation="equal" column="ggmailing_board_srl" var="ggmailing_board_srl" notnull="notnull" />
     </conditions>
 </query>

--- a/queries/deleteGgmailingDonotsend.xml
+++ b/queries/deleteGgmailingDonotsend.xml
@@ -1,0 +1,10 @@
+<query id="deleteGgmailingDonotsend" action="delete">
+    <tables>
+        <table name="ggmailing_donotsends" />
+    </tables>
+    <columns>
+    </columns>   
+    <conditions>
+        <condition operation="equal" column="ggmailing_donotsend_srl" var="ggmailing_donotsend_srl" />
+    </conditions>
+</query>

--- a/queries/getBoardMember.xml
+++ b/queries/getBoardMember.xml
@@ -8,5 +8,6 @@
     <conditions>
 		<condition operation="equal" column="ggmailing_member_srl" var="ggmailing_member_srl" />
 		<condition operation="equal" column="ggmailing_module_srl" var="ggmailing_module_srl" pipe="and" />
+        <condition operation="equal" column="ggmailing_email" var="ggmailing_email" pipe="and" />
     </conditions>
 </query>

--- a/queries/getDonotsendList.xml
+++ b/queries/getDonotsendList.xml
@@ -1,0 +1,19 @@
+<query id="getDonotsendList" action="select">
+    <tables>
+        <table name="ggmailing_donotsends" />
+    </tables>
+    <columns>
+        <column name="*" />
+    </columns>   
+    <conditions>
+		<condition operation="like" column="ggmailing_nickname" var="ggmailing_nickname" />
+        <condition operation="equal" column="ggmailing_member_srl" var="ggmailing_member_srl" pipe="and" />
+		<condition operation="like" column="ggmailing_email" var="ggmailing_email" pipe="and" />
+    </conditions>
+    <navigation>
+        <index var="sort_index" default="ggmailing_donotsend_srl" order="desc" />
+        <list_count var="list_count" default="20" />
+        <page_count var="page_count" default="10" />
+        <page var="page" default="1" />
+    </navigation>
+</query>

--- a/tpl/boardmailing.html
+++ b/tpl/boardmailing.html
@@ -19,6 +19,7 @@
 			<th>{$lang->receive_nickname}</th>
 			<th>{$lang->receive_email}</th>
 			<th>{$lang->mid}</th>
+			<th>Document Srl</th>
 			<th>{$lang->regdate}</th>
 			<th>{$lang->delete}</th>
 		 </tr>
@@ -30,6 +31,7 @@
 				<td>{$val->ggmailing_nickname}</td>
 				<td>{$val->ggmailing_email}</td>
 				<td>{$val->ggmailing_mid}</td>
+				<td>{$val->ggmailing_document_srl}</td>
 				<td>{zdate($val->regdate,'Y-m-d H:i:s')}</td>
 				<td width="40">
 				<form action="" method="post">

--- a/tpl/boardmailing.html
+++ b/tpl/boardmailing.html
@@ -3,6 +3,7 @@
 <div>
 - 게시판 메일링 회원은 Module Srl만 존재합니다.<br />
 - 댓글알림 회원은 Document Srl만 존재합니다.<br />
+- 뉴스레터 회원은 Module Srl만 존재하며 비회윈의 경우 Member Srl 이 '0'일수도 있습니다.<br />
 </div>
 <form action="./" method="POST" style="float:left;">
 <span>Total:{$total_count}, Page:{$page}/{$total_page}</span>
@@ -25,19 +26,24 @@
 			<th>{$lang->mid}</th>
 			<th>Module Srl</th>
 			<th>Document Srl</th>
+			<th>Member Srl</th>
 			<th>{$lang->regdate}</th>
 			<th>{$lang->delete}</th>
 		 </tr>
 	</thead>
 	<tbody>
 		<!--@foreach($bm_info as $key => $val)-->
+		{@
+			$_newsletter_mid = explode(',',$config->newsletter_mid);
+		}
 			<tr style="border-top:1px solid #ddd;">
 				<td>{$key}</td>
 				<td>{$val->ggmailing_nickname}</td>
 				<td>{$val->ggmailing_email}</td>
-				<td>{$val->ggmailing_mid}</td>
+				<td>{$val->ggmailing_mid}<block cond="in_array($val->ggmailing_mid,$_newsletter_mid)">(newsletter)</block></td>
 				<td>{$val->ggmailing_module_srl}</td>
 				<td>{$val->ggmailing_document_srl}</td>
+				<td>{$val->ggmailing_member_srl}</td>
 				<td>{zdate($val->regdate,'Y-m-d H:i:s')}</td>
 				<td width="40">
 				<form action="" method="post">

--- a/tpl/boardmailing.html
+++ b/tpl/boardmailing.html
@@ -1,5 +1,9 @@
 <!--#include("./header.html")-->
 <h3 class="sub_title">{$lang->boardmailing}</h3>
+<div>
+- 게시판 메일링 회원은 Module Srl만 존재합니다.<br />
+- 댓글알림 회원은 Document Srl만 존재합니다.<br />
+</div>
 <form action="./" method="POST" style="float:left;">
 <span>Total:{$total_count}, Page:{$page}/{$total_page}</span>
 <input type="hidden" name="act" value="dispGgmailingAdminBoardMailing" />
@@ -19,6 +23,7 @@
 			<th>{$lang->receive_nickname}</th>
 			<th>{$lang->receive_email}</th>
 			<th>{$lang->mid}</th>
+			<th>Module Srl</th>
 			<th>Document Srl</th>
 			<th>{$lang->regdate}</th>
 			<th>{$lang->delete}</th>
@@ -31,14 +36,14 @@
 				<td>{$val->ggmailing_nickname}</td>
 				<td>{$val->ggmailing_email}</td>
 				<td>{$val->ggmailing_mid}</td>
+				<td>{$val->ggmailing_module_srl}</td>
 				<td>{$val->ggmailing_document_srl}</td>
 				<td>{zdate($val->regdate,'Y-m-d H:i:s')}</td>
 				<td width="40">
 				<form action="" method="post">
 				<input type="hidden" name="module" value="admin" />
 				<input type="hidden" name="act" value="procGgmailingAdminBoardmailingDelete" />
-				<input type="hidden" name="ggmailing_module_srl" value="{$val->ggmailing_module_srl}" />
-				<input type="hidden" name="ggmailing_member_srl" value="{$val->ggmailing_member_srl}" />
+				<input type="hidden" name="ggmailing_board_srl" value="{$val->ggmailing_board_srl}" />
 				<input type="submit" class="xet_btn medium red" value="{$lang->delete}" onclick="javascript:if(confirm('{$lang->wantdel}')) return; else return false;" />
 				</form>
 				</td>

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -91,6 +91,7 @@
 						<label>게시판 댓글알림 사용함</label>
 						<p class="ggm_example">
 							<a href="#" target="_blank">게시판 댓글알림 위젯</a>을 사용할 것인지 여부를 선택합니다.<br />
+							댓글 등록자 자신에게는 메일이 오지 않습니다.<br />
 						</p>
 					</td>
 				</tr>
@@ -102,6 +103,28 @@
 							게시판 댓글알림에서 사용할 닉네임을 설정합니다.<br />
 							닉네임을 설정하지 않으면 본 홈페이지 도메인이 닉네임으로 전송됩니다.<br />
 							<xmp>닉네임<NOREPLY@woorimail.com></xmp>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th width="200px">게시판 댓글알림 MID 설정</th>
+					<td>
+						<input type="text" name="ward_mid" value="{$config->ward_mid}" /> 
+						<p class="ggm_example">
+							게시판 댓글알림 MID 설정을 해야만 해당 게시판의 게시물의 댓글이 등록될 때 게시판 댓글알림이 작동합니다.<br />
+							다수의 게시판을 설정할 경우 컴머(,)를 이용해서 등록하세요.<br />
+							게시판 댓글알림 사용함을 함께 설정 해야 합니다.<br />
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th width="200px">게시판 메일링 MID 설정</th>
+					<td>
+						<input type="text" name="boardmailing_mid" value="{$config->boardmailing_mid}" /> 
+						<p class="ggm_example">
+							게시판 메일링 MID 설정을 해야만 해당 게시판의 게시물이 등록될 때 게시판 메일링이 작동합니다.<br />
+							다수의 게시판을 설정할 경우 컴머(,)를 이용해서 등록하세요.<br />
+							게시판 메일링 사용함을 함께 설정 해야 합니다.<br />
 						</p>
 					</td>
 				</tr>

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -106,14 +106,27 @@
 					</td>
 				</tr>
 				<tr>
-					<th width="200px">게시판 메일링 사용 여부</th>
+					<th width="200px">뉴스레터 게시판 MID 설정</th>
+					<td>
+						<input type="text" name="newsletter_mid" value="{$config->newsletter_mid}" /> 
+						<p class="ggm_example">
+							뉴스레터 게시판 MID 설정을 하게 되면 설정된 게시판의 게시판 메일링은 제목/내용을 게시물 그대로 전송합니다.<br />
+							다수의 게시판을 설정할 경우 컴머(,)를 이용해서 등록하세요.<br />
+							게시판 메일링 사용함을 함께 설정 해야 합니다.<br />
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th width="200px">게시판메일링/뉴스레터 사용 여부</th>
 					<td>
 						<input type="radio" name="type_board_mailing" value="F" checked="checked"|cond="!$config->type_board_mailing || $config->type_board_mailing == 'F'" /> 
-						<label>게시판 메일링 사용 안함</label><br />
+						<label>게시판메일링/뉴스레터 사용 안함</label><br />
 						<input type="radio" name="type_board_mailing" value="Y" checked="checked"|cond="$config->type_board_mailing == 'Y'" /> 
-						<label>게시판 메일링 사용함</label>
+						<label>게시판메일링/뉴스레터 사용함</label>
 						<p class="ggm_example">
 							<a href="http://www.xpressengine.com/index.php?mid=download&package_id=22753306" target="_blank">게시판 메일링 위젯</a>을 사용할 것인지 여부를 선택합니다.<br />
+							<a href="#" target="_blank">뉴스레터 위젯</a>을 사용할 것인지 여부를 선택합니다.<br />
+							게시물 등록자 자신에게는 메일이 오지 않습니다.<br />
 						</p>
 					</td>
 				</tr>
@@ -124,6 +137,7 @@
 						<p class="ggm_example">
 							게시판 메일링에서 사용할 닉네임을 설정합니다.<br />
 							닉네임을 설정하지 않으면 본 홈페이지 도메인이 닉네임으로 전송됩니다.<br />
+							뉴스레터에는 적용되지 않습니다.<br />
 							<xmp>닉네임<NOREPLY@woorimail.com></xmp>
 						</p>
 					</td>
@@ -138,6 +152,7 @@
 							치환변수) 게시판명 {board_title}, 글쓴이 닉네임 {nick_name}, 게시물 내용 {board_content}<br />
 							제목 예) [메일링] {board_title} 게시판 {nick_name}님의 게시물입니다.<br />
 							내용 예) {board_title} 게시판에 {nick_name} 님의 새 글이 등록되었습니다. {board_content}<br />
+							뉴스레터에는 적용되지 않습니다.<br />
 						</p>
 					</td>
 				</tr>

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -34,10 +34,10 @@
 					<th width="200px" rowspan="2"><em><font color="red">*</font></em>대량 메일서비스 서버 선택</th>
 					<td>
 						<input id="myServ1" onchange="serv_checked()" type="radio" name="ggmailing_serv_url" value="woorimail.com" checked="checked"|cond="!$config->ggmailing_serv_url || $config->ggmailing_serv_url == 'woorimail.com'" /> 
-						<label>우리메일 공식 무료 서버</label>
+						<label>우리메일 공식 무료 서버(기본:woorimail.com)</label>
 						<br />
 						<input id="myServ2" onchange="serv_checked()" type="radio" name="ggmailing_serv_url" value="URL을 입력하세요." checked="checked"|cond="$config->ggmailing_serv_url && $config->ggmailing_serv_url != 'woorimail.com'" /> 
-						<label>커스텀 대량메일 시스템 구축 서버</label><br />
+						<label>커스텀 대량메일 시스템 구축 서버(옵션)</label><br />
 						URL : <input id="myServUrl" type="text" name="ggmailing_serv_url" value="{$config->ggmailing_serv_url}"|cond="$config->ggmailing_serv_url && $config->ggmailing_serv_url != 'woorimail.com'" value="woorimail.com"|cond="$config->ggmailing_serv_url == 'woorimail.com' || !$config->ggmailing_serv_url" />
 						<p class="ggm_example">URL을 공란으로 비워두시면 모듈이 작동하지 않습니다.</p>
 						<input type="radio" name="ggmailing_ssl" value="Y" checked="checked"|cond="$config->ggmailing_ssl == 'Y'" />
@@ -47,7 +47,7 @@
 						<label>SSL 보안전송 미사용</label>
 						&nbsp;&nbsp;&nbsp;
 						(포트 : <input type="text" id="myPort" name="ggmailing_ssl_port" value="80"|cond="$config->ggmailing_ssl == 'N'" value="{$config->ggmailing_ssl_port}"|cond="$config->ggmailing_ssl == 'Y'" style="width:50px;" />)
-						<p class="ggm_example">무료서버 SSL 보안전송 사용시 포트 20080 을 반드시 입력합니다.</p>
+						<p class="ggm_example">무료서버 SSL 보안전송 사용시 포트 20080 을 반드시 입력합니다. 20080포트를 지원하지 않으면 SSL 보안전송 미사용(80번 포트)을 사용합니다.</p>
 					</td>
 				</tr>
 				<tr>
@@ -71,14 +71,37 @@
 					</td>
 				</tr>
 				<tr>
-					<th width="200px">전용 서버 사용 여부</th>
+					<th width="200px">전용 채널/서버 사용 여부</th>
 					<td>
 						<input type="radio" name="type_server" value="F" checked="checked"|cond="!$config->type_server || $config->type_server == 'F'" /> 
-						<label>전용 서버 사용 안함</label><br />
+						<label>전용 채널/서버 사용 안함(무료)</label><br />
 						<input type="radio" name="type_server" value="Y" checked="checked"|cond="$config->type_server == 'Y'" /> 
-						<label>전용 서버 사용함</label>
+						<label>전용 채널/서버 사용함(유료)</label>
 						<p class="ggm_example">
 							전용 서버를 설치하여 사용할지 여부를 선택합니다.
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th width="200px">게시판 댓글알림 사용 여부</th>
+					<td>
+						<input type="radio" name="type_ward" value="F" checked="checked"|cond="!$config->type_ward || $config->type_ward == 'F'" /> 
+						<label>게시판 댓글알림 사용 안함</label><br />
+						<input type="radio" name="type_ward" value="Y" checked="checked"|cond="$config->type_ward == 'Y'" /> 
+						<label>게시판 댓글알림 사용함</label>
+						<p class="ggm_example">
+							<a href="#" target="_blank">게시판 댓글알림 위젯</a>을 사용할 것인지 여부를 선택합니다.<br />
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th width="200px">게시판 댓글알림 닉네임 설정</th>
+					<td>
+						<input type="text" name="type_ward_nick" value="{$config->type_ward_nick}" style="width:300px;" /><br />
+						<p class="ggm_example">
+							게시판 댓글알림에서 사용할 닉네임을 설정합니다.<br />
+							닉네임을 설정하지 않으면 본 홈페이지 도메인이 닉네임으로 전송됩니다.<br />
+							<xmp>닉네임<NOREPLY@woorimail.com></xmp>
 						</p>
 					</td>
 				</tr>
@@ -143,13 +166,14 @@
 					</td>
 				</tr>
 				<tr>
-					<th width="200px">XE 코어 연동 사용 여부</th>
+					<th width="200px">XE 코어 연동 사용 여부<br />(XE 1.8.3미만 버전용)</th>
 					<td>
 						<input type="radio" name="type_xe_send" value="F" checked="checked"|cond="!$config->type_xe_send || $config->type_xe_send == 'F'" /> 
 						<label>XE 코어 연동 사용 안함</label><br />
 						<input type="radio" name="type_xe_send" value="Y" checked="checked"|cond="$config->type_xe_send == 'Y'" /> 
 						<label>XE 코어 연동 사용함</label>
 						<p class="ggm_example">
+							XE 1.8.3 부터는 <a href="https://www.xpressengine.com/index.php?mid=download&package_id=22753677" target="_blank">고급메일발송모듈</a> 을 이용해 주세요.
 							XE 코어 연동을 사용할 것인지 여부를 선택합니다.<br />
 							이 옵션을 사용하면 XE 코어에서 전송하는 이메일이 모두 우리알림으로 전송됩니다.<br />
 							회신 미지원 이메일 형태이며 파일첨부를 지원하지 않습니다.<br />

--- a/tpl/donotsend_list.html
+++ b/tpl/donotsend_list.html
@@ -1,0 +1,65 @@
+<!--#include("./header.html")-->
+<h3 class="sub_title">{$lang->donotsend_list}</h3>
+<form action="./" method="POST" style="float:left;">
+<span>Total:{$total_count}, Page:{$page}/{$total_page}</span>
+<input type="hidden" name="act" value="dispGgmailingAdminDonotsend" />
+<input type="hidden" name="module" value="admin" />
+<select name="search_type" style="margin-top:10px; width:100px;">
+	<option value="ggmailing_email" selected="selected"|cond="!$args->search_type || $args->search_type=='ggmailing_email'" />{$lang->receive_email}
+	<option value="ggmailing_nickname" selected="selected"|cond="$args->search_type=='ggmailing_nickname'" />{$lang->nick_name}
+	<option value="ggmailing_member_srl" selected="selected"|cond="$args->search_type=='ggmailing_member_srl'" />Member Srl
+</select>
+<input type="text" name="search_keyword" value="{$args->search_keyword}" style="margin-top:10px;" />
+<input class="xet_btn medium blue" type="submit" value="{$lang->cmd_search}" />
+</form>
+<table class="index_table">
+
+	<thead>
+		<tr>
+			<th rowspan="2">no.</th>
+			<th>{$lang->receive_nickname}</th>
+			<th>Member Srl</th>
+			<th>{$lang->receive_email}</th>
+			<th>{$lang->regdate}</th>
+			<th>{$lang->delete}</th>
+		 </tr>
+	</thead>
+	<tbody>
+		<!--@foreach($ds_info as $key => $val)-->
+			<tr style="border-top:1px solid #ddd;">
+				<td>{$key}</td>
+				<td>{$val->ggmailing_nickname}</td>
+				<td>{$val->ggmailing_member_srl}</td>
+				<td>{$val->ggmailing_email}</td>
+				<td>{zdate($val->regdate,'Y-m-d H:i:s')}</td>
+				<td width="40">
+				<form action="" method="post">
+				<input type="hidden" name="module" value="admin" />
+				<input type="hidden" name="act" value="procGgmailingAdminDonotsendDelete" />
+				<input type="hidden" name="ggmailing_donotsend_srl" value="{$val->ggmailing_donotsend_srl}" />
+				<input type="submit" class="xet_btn medium red" value="{$lang->delete}" onclick="javascript:if(confirm('{$lang->wantdel}')) return; else return false;" />
+				</form>
+				</td>
+			</tr>
+		<!--@end-->
+	</tbody>
+</table>
+
+
+<form action="./" class="ggm_pagination">
+	<input type="hidden" name="error_return_url" value="" />
+	<input type="hidden" name="module" value="{$module}" />
+	<input type="hidden" name="act" value="{$act}" />
+	<ul>
+		<li class="disabled"|cond="!$page || $page == 1"><a href="{getUrl('page', '')}">&laquo; {$lang->first_page}</a></li>
+
+		<!--@while($page_no = $page_navigation->getNextPage())-->
+		{@$last_page = $page_no}
+		<li class="active"|cond="$page_no == $page"><a  href="{getUrl('page', $page_no)}">{$page_no}</a></li>
+		<!--@end-->
+
+		<li class="disabled"|cond="$page == $page_navigation->last_page"><a href="{getUrl('page', $page_navigation->last_page)}" title="{$page_navigation->last_page}">{$lang->last_page} &raquo;</a></li>
+	</ul>
+</form>
+
+<!--#include("./footer.html")-->

--- a/tpl/header.html
+++ b/tpl/header.html
@@ -86,6 +86,8 @@ $module_list = $oModuleModel->getModuleList();
 				jQuery("#ggmember").show();
 				jQuery("#ggmember2").show();
 				jQuery("#boardmailing").show();
+				jQuery("#boardmailing2").show();
+				jQuery("#donotsend").show();
 			},
 			global: false,
 			cache: false,
@@ -191,18 +193,11 @@ $module_list = $oModuleModel->getModuleList();
         <li class="ggtopMenuLi" style="display:none;" id="boardmailing">
             <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminBoardMailing')}">{$lang->boardmailing}</a>
         </li>
-		<!--
-        <li>|</li>
+        <li style="display:none;" id="boardmailing2">|</li>
 
-        <li class="ggtopMenuLi">
-            <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispNcenterliteAdminList')}">알림목록</a>
+		<li class="ggtopMenuLi" style="display:none;" id="donotsend">
+            <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminDonotsend')}">{$lang->donotsendlist}</a>
         </li>
-		<li>|</li>
-
-        <li class="ggtopMenuLi">
-            <a class="ggmenuLink" href="http://woorimail.com/send_result" target="_blank">메일발송내역</a>
-        </li>
-		-->
 		<!--@end-->
     </ul>
 </nav>

--- a/tpl/header.html
+++ b/tpl/header.html
@@ -1,6 +1,7 @@
 <load target="css/style.css" />
 <load target="css/button.css" />
 <load target="css/woorimail.css" />
+
 {@
 // 버전 구하기
 $args->path = './modules/ggmailing';
@@ -9,13 +10,91 @@ $oModuleModel = getModel('module');
 $module_list = $oModuleModel->getModuleList();
 }
 <div class="x_page-header">
-	<h1>{$lang->mailing} v<!--@foreach($module_list as $key => $val)--><!--@if($val->path == './modules/ggmailing/')-->{$val->version}{@ $current_ver = $val->version; }<!--@end--><!--@end--></h1>
+	<h1>{$lang->woorialim} v<!--@foreach($module_list as $key => $val)--><!--@if($val->path == './modules/ggmailing/')-->{$val->version}{@ $current_ver = $val->version; }<!--@end--><!--@end--></h1>
 	<!--@if($current_ver < $authcheck->check_ver)-->
 	<h3>최신버전 : v{$authcheck->check_ver}
 	<a href="{$authcheck->check_file}">[다운로드]</a>
 	<!--@end-->
 	</h3>
 </div>
+{@
+	$dmn = getFullUrl('');
+	$dmn = parse_url($dmn);
+	$domain = substr($dmn['host'] . $dmn['path'], 0, -1);
+	$domain = str_replace('www.','',$domain);
+	
+	$ggmailing_serv_url = $config->ggmailing_serv_url;
+}
+<!--@if($config->ggmailing_ssl == 'N' || !$config->ggmailing_ssl)--> {@ $ggmailing_ssl = 'http://'; $ggmailing_ssl_port = ''; } <!--@elseif($config->ggmailing_ssl == 'Y')--> { $ggmailing_ssl = 'https://'; $ggmailing_ssl_port = ':' . $config->ggmailing_ssl_port; }<!--@end-->
+{@
+	$url = $ggmailing_ssl . $ggmailing_serv_url . $ggmailing_ssl_port . '/index.php';
+	
+	$post_data = array(
+			'act' => 'dispWwapimanagerRequest',
+			'authkey' => $config->ggmailing_authkey,
+			'mid' => 'auth_woorimail',
+			'domain' => $domain,
+			'type' => 'ggmailing'
+	);
+}
+<script>
+	jQuery(document).ready(function() {
+		var url = '{$url}';
+
+		var formData = new FormData();
+
+		var act = '{$post_data[act]}';
+		formData.append("act",act);
+		var authkey = '{$post_data[authkey]}';
+		formData.append("authkey",authkey);
+		var mid = '{$post_data[mid]}';
+		formData.append("mid",mid);
+		var domain = '{$post_data[domain]}';
+		formData.append("domain",domain);
+		var type = '{$post_data[type]}';
+		formData.append("type",type);
+
+		jQuery.ajax({
+			url: url,
+			type: 'POST',
+			data: formData,
+			async: true,
+			success: function (data) {
+				//alert(data);
+				var result = JSON.parse(data);
+				if(result.ggauth_check == 'OK') document.getElementById('ggauth_check').innerHTML = 'OK';
+				else document.getElementById('ggauth_check').innerHTML = '서버점검중';
+
+				if(result.free_point>0) document.getElementById('free_point').innerHTML = Number(result.free_point).toLocaleString('en');
+				else document.getElementById('free_point').innerHTML = '0';
+				if(result.pay_point>0) document.getElementById('pay_point').innerHTML = Number(result.pay_point).toLocaleString('en');
+				else document.getElementById('pay_point').innerHTML = '0';
+				if(result.event_point>0) document.getElementById('event_point').innerHTML = Number(result.event_point).toLocaleString('en');
+				else document.getElementById('event_point').innerHTML = '0';
+				if(result.etc_point>0) document.getElementById('etc_point').innerHTML = Number(result.etc_point).toLocaleString('en');
+				else document.getElementById('etc_point').innerHTML = '0';
+
+				if(result.freemail_wait>0) document.getElementById('freemail_wait').innerHTML = Number(result.freemail_wait).toLocaleString('en');
+				else document.getElementById('freemail_wait').innerHTML = '0';
+				if(result.paymail_wait>0) document.getElementById('paymail_wait').innerHTML = Number(result.paymail_wait).toLocaleString('en');
+				else document.getElementById('paymail_wait').innerHTML = '0';
+
+				jQuery("#ggnotice").show();
+				jQuery("#ggnotice2").show();
+				jQuery("#ggmail").show();
+				jQuery("#ggmail2").show();
+				jQuery("#ggmember").show();
+				jQuery("#ggmember2").show();
+				jQuery("#boardmailing").show();
+			},
+			global: false,
+			cache: false,
+			contentType: false,
+			processData: false
+		});
+		return false;
+	})
+</script>
 <div class="woorimail">
 	<div class="cols">
 		<div class="col2">
@@ -24,19 +103,19 @@ $module_list = $oModuleModel->getModuleList();
 				<table class="table_line">
 					<tr>
 						<th scope="col">{$lang->pay_point}</th>
-						<td>{number_format($authcheck->pay_point?$authcheck->pay_point:0)}</td>
+						<td><div id="pay_point"></div></td>
 					</tr>
 					<tr>
 						<th scope="col">{$lang->etc_point}</th>
-						<td>{number_format($authcheck->etc_point?$authcheck->etc_point:0)}</td>
+						<td><div id="etc_point"></div></td>
 					</tr>
 					<tr>
 						<th scope="col">{$lang->free_point}</th>
-						<td>{number_format($authcheck->free_point?$authcheck->free_point:0)}</td>
+						<td><div id="free_point"></div></td>
 					</tr>
 					<tr>
 						<th scope="col">{$lang->promotion_point}</th>
-						<td>{number_format($authcheck->event_point?$authcheck->event_point:0)}</td>
+						<td><div id="event_point"></div></td>
 					</tr>
 				</table>
 			</div>
@@ -47,15 +126,15 @@ $module_list = $oModuleModel->getModuleList();
 				<div class="statewrap">
 					<div class="state_area">
 						<strong>{$lang->authcheck}</strong>
-						<div class="icon"><span class="error">{$authcheck->ggauth_check}</span></div>
+						<div class="icon"><span class="error"><div id="ggauth_check"></div></span></div>
 					</div>
 					<div class="state_area">
 						<strong>{$lang->paymail_ready}</strong>
-						<div class="num">{number_format($authcheck->paymail_wait?$authcheck->paymail_wait:0)}</div>
+						<div class="num"><div id="paymail_wait"></div></div>
 					</div>
 					<div class="state_area">
 						<strong>{$lang->freemail_ready}</strong>
-						<div class="num">{number_format($authcheck->freemail_wait?$authcheck->freemail_wait:0)}</div>
+						<div class="num"><div id="freemail_wait"></div></div>
 					</div>
 				</div>
 			</div>
@@ -67,11 +146,11 @@ $module_list = $oModuleModel->getModuleList();
 
 <nav id="ggtopMenu" >
     <ul>
-		<!--@if($authcheck->ggauth_check == 'OK' && $config->accept_agree == 'Y' && $authcheck->type_member == 'G')-->
-        <li class="ggtopMenuLi">
+		<!--@if($config->accept_agree == 'Y')-->
+        <li class="ggtopMenuLi" style="display:none;" id="ggnotice">
             <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminNotice')}">공지</a>
         </li>
-        <li>|</li>
+        <li style="display:none;" id="ggnotice2">|</li>
 		<!--@end-->
         <li class="ggtopMenuLi">
             <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminIndex')}">{$lang->manual}</a>
@@ -83,8 +162,8 @@ $module_list = $oModuleModel->getModuleList();
         </li>
         <li>|</li>
 
-		<!--@if($authcheck->ggauth_check == 'OK' && $config->accept_agree == 'Y' && $authcheck->type_member == 'G')-->
-        <li class="ggtopMenuLi">
+		<!--@if($config->accept_agree == 'Y')-->
+        <li class="ggtopMenuLi" style="display:none;" id="ggmail">
             <a class="ggmenuLink" href="#">대량 EMAIL</a>
             <ul class="ggsubmenu">
                 <li><a class="ggsubmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminInsert')}">{$lang->insert_mail}</a></li>
@@ -92,7 +171,7 @@ $module_list = $oModuleModel->getModuleList();
                 <li><a class="ggsubmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminSend')}">{$lang->send_list}</a></li>
             </ul>
         </li>
-        <li>|</li>
+        <li style="display:none;" id="ggmail2">|</li>
 
         <li class="ggtopMenuLi" cond="0">
             <a class="ggmenuLink" href="#">대량 SMS/LMS/MMS</a>
@@ -104,12 +183,12 @@ $module_list = $oModuleModel->getModuleList();
         </li>
         <li cond="0">|</li>
 
-        <li class="ggtopMenuLi">
+        <li class="ggtopMenuLi" style="display:none;" id="ggmember">
             <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminInsertmembers')}">{$lang->insertmembers}</a>
         </li>
-        <li>|</li>
+        <li style="display:none;" id="ggmember2">|</li>
 
-        <li class="ggtopMenuLi">
+        <li class="ggtopMenuLi" style="display:none;" id="boardmailing">
             <a class="ggmenuLink" href="{getUrl('','module','admin','act','dispGgmailingAdminBoardMailing')}">{$lang->boardmailing}</a>
         </li>
 		<!--

--- a/tpl/index.html
+++ b/tpl/index.html
@@ -2,7 +2,7 @@
 <h2>{$lang->manual}</h2>
 
 <div class="infoText">
-	<blockquote>{nl2br($lang->about_mailing)}</blockquote>
+	<blockquote>{nl2br($lang->about_woorialim)}</blockquote>
 </div>
 
 <div class="warnning">
@@ -23,7 +23,6 @@
 			<th>{$lang->manual_configure}</th>
 			<td>{$lang->manual_configure_content}</td>
 		</tr>
-	<!--@if($authcheck->type_member == 'G')-->
 		<tr>
 			<th>{$lang->manual_insert}</th>
 			<td>{$lang->manual_insert_content}</td>
@@ -44,7 +43,6 @@
 			<th>{$lang->manual_changestr}</th>
 			<td>{$lang->manual_changestr_content}</td>
 		</tr>
-	<!--@end-->
 		<tr>
 			<th>{$lang->manual_boardmailing}</th>
 			<td>{$lang->manual_boardmailing_content}</td>

--- a/tpl/mailing.html
+++ b/tpl/mailing.html
@@ -4,7 +4,7 @@
 <div class="warnning">
 	상업적 용도의 이메일은 반드시 합법적 스팸메일 작성 가이드 기준에 맞게 제목과 내용을 입력하셔야 합니다. <br />
 	만약 가이드에 맞지 않게 불법 스팸메일을 전송할 경우 발송자에게 민,형사상 책임이 발생할 수 있습니다.<br />
-	<a href="https://spam.kisa.or.kr/kor/jsp/down.jsp?filename=2011_%EC%82%AC%EC%97%85%EC%9E%90%EB%A5%BC_%EC%9C%84%ED%95%9C_%EB%B6%88%EB%B2%95%EC%8A%A4%ED%8C%B8%EB%B0%A9%EC%A7%80_%EC%95%88%EB%82%B4%EC%84%9C%28%EC%9D%B4%EB%A9%94%EC%9D%BC%29.pdf" target="_blank">[합법적 스팸메일 작성 가이드]</a>
+	<a href="http://woorimail.com/105782" target="_blank">[합법적 스팸메일 작성 가이드]</a>
 </div>
 
 <form action="./" method="post" name="ggform">
@@ -101,7 +101,7 @@
 					 $option->enable_component = false;
 					 $option->resizable = true;
 					 $option->height = 300; 
-					 $option->skin = "xpresseditor";
+					 $option->skin = "CKEditor" ? "CKEditor" : "xpresseditor";
 					 $editor = $oEditorModel->getEditor($args->ggmailing_document_srl, $option);
 					 //$editor->editor_sequence;
 					}

--- a/tpl/notice.html
+++ b/tpl/notice.html
@@ -1,7 +1,75 @@
 <!--#include("./header.html")-->
 
 <h3 class="sub_title">공지</h3>
+{@
+	$dmn = getFullUrl('');
+	$dmn = parse_url($dmn);
+	$domain = substr($dmn['host'] . $dmn['path'], 0, -1);
+	$domain = str_replace('www.','',$domain);
+	
+	$ggmailing_serv_url = $config->ggmailing_serv_url;
+}
+<!--@if($config->ggmailing_ssl == 'N' || !$config->ggmailing_ssl)--> {@ $ggmailing_ssl = 'http://'; $ggmailing_ssl_port = ''; } <!--@elseif($config->ggmailing_ssl == 'Y')--> {@ $ggmailing_ssl = 'https://'; $ggmailing_ssl_port = ':' . $config->ggmailing_ssl_port; }<!--@end-->
+{@
+	$url = $ggmailing_ssl . $ggmailing_serv_url . $ggmailing_ssl_port . '/index.php';
+	$post_data = array(
+			'act' => 'dispWwapimanagerRequest',
+			'authkey' => $config->ggmailing_authkey,
+			'mid' => 'auth_woorimail',
+			'domain' => $domain,
+			'type' => 'ggmailing',
+			'notice_mid' => 'notice' // 공지를 mid 값으로 호출
+	);
+}
+<script>
+	jQuery(document).ready(function() {
+		var url = '{$url}';
 
+		var formData = new FormData();
+
+		var act = '{$post_data[act]}';
+		formData.append("act",act);
+		var authkey = '{$post_data[authkey]}';
+		formData.append("authkey",authkey);
+		var mid = '{$post_data[mid]}';
+		formData.append("mid",mid);
+		var domain = '{$post_data[domain]}';
+		formData.append("domain",domain);
+		var type = '{$post_data[type]}';
+		formData.append("type",type);
+		var notice_mid = '{$post_data[notice_mid]}';
+		formData.append("notice_mid",notice_mid);
+
+		jQuery.ajax({
+			url: url,
+			type: 'POST',
+			data: formData,
+			async: true,
+			success: function (data) {
+				//alert(data);
+				var result = JSON.parse(data);
+				for (var i = 0; i < 10; i++)
+				{
+					document.getElementById('notice_'+i).innerHTML = '<a href="'+url+'?document_srl='+result.notice_no[i]+'" target="_blank">'+result.notice_title[i]+'</a>';
+					var string = result.notice_regdate[i];
+					var year = string.substring(0,4);
+					var month = string.substring(4,6);
+					var day = string.substring(6,8);
+					//var hour = string.substring(8,10);
+					//var minite = string.substring(10,12);
+					//var second = string.substring(12,14);
+					//document.getElementById('regdate_'+i).innerHTML = year + '/' + month + '/' + day + ' ' + hour + ':' + minite + ':' + second;
+					document.getElementById('regdate_'+i).innerHTML = year + '/' + month + '/' + day;
+				}
+			},
+			global: false,
+			cache: false,
+			contentType: false,
+			processData: false
+		});
+		return false;
+	})
+</script>
 <table class="index_table">
 	<thead>
 		<tr>
@@ -14,8 +82,8 @@
 			<!--@for($i=0;$i<10;$i++)-->
 			<tr style="border-top:1px solid #ddd;">
 				<td style="text-align:center;">{$i+1}</td>
-				<td><a href="{$notice->url}?mid={$notice->mid}&document_srl={$notice->notice_no[$i]}" target="_blank">{$notice->notice_title[$i]}</a></td>
-				<td style="text-align:center;">{zdate($notice->notice_regdate[$i],'Y-m-d H:i:s')}</td>
+				<td id="notice_{$i}"></td>
+				<td style="text-align:center;" id="regdate_{$i}"></td>
 			</tr>
 			<!--@endfor-->
 	</tbody>

--- a/tpl/send.html
+++ b/tpl/send.html
@@ -1,9 +1,11 @@
 <!--#include("./header.html")-->
+
 <!--@if(Context::get('type')!='status')-->
 <h3 class="sub_title">{$lang->send_list}</h3>
 <!--@else-->
 <h3 class="sub_title">메일전송 현황</h3>
 <!--@end-->
+
 <table class="index_table">
 <span>Total:{$total_count}, Page:{$page}/{$total_page}</span>
 	<thead>
@@ -65,42 +67,64 @@
 						'ggmailing_document_srl' => $val->ggmailing_document_srl,
 						'ggmailing_send_srl' => $val->ggmailing_send_srl
 				);
-				$ch = curl_init();
-				curl_setopt($ch, CURLOPT_URL,$url);
-				curl_setopt($ch, CURLOPT_POST,1);
-				curl_setopt($ch, CURLOPT_POSTFIELDS,$post_data);
-				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			}
-			<!--@if($config->ggmailing_ssl == 'Y')-->
-			{@
-				curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
-				curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-			}
-			<!--@end-->
-			{@
-				$response = curl_exec($ch);
-				$authcheck = json_decode($response);
-				curl_close($ch);
-			}
-			
+			<script>
+				jQuery(document).ready(function() {
+					var url = '{$url}';
+
+					var formData = new FormData();
+
+					var act = '{$post_data[act]}';
+					formData.append("act",act);
+					var authkey = '{$post_data[authkey]}';
+					formData.append("authkey",authkey);
+					var mid = '{$post_data[mid]}';
+					formData.append("mid",mid);
+					var domain = '{$post_data[domain]}';
+					formData.append("domain",domain);
+					var type = '{$post_data[type]}';
+					formData.append("type",type);
+					var ggmailing_document_srl = '{$post_data[ggmailing_document_srl]}';
+					formData.append("ggmailing_document_srl",ggmailing_document_srl);
+					var ggmailing_send_srl = '{$post_data[ggmailing_send_srl]}';
+					formData.append("ggmailing_send_srl",ggmailing_send_srl);
+
+					jQuery.ajax({
+						url: url,
+						type: 'POST',
+						data: formData,
+						async: true,
+						success: function (data) {
+							//alert(data);
+							var result = JSON.parse(data);
+							if(result.is_sendok == 'Y') document.getElementById('ggstatus_{$key}').innerHTML = '{$lang->send_complete}';
+							else if(result.is_sendok == 'B') document.getElementById('ggstatus_{$key}').innerHTML = '대기열';
+							else if(result.is_sendok == 'W') document.getElementById('ggstatus_{$key}').innerHTML = '전송대기';
+							else if(result.is_sendok == 'S') document.getElementById('ggstatus_{$key}').innerHTML = '전송중';
+							else if(result.is_sendok == 'E') document.getElementById('ggstatus_{$key}').innerHTML = '오류';
+							else if(!result) document.getElementById('ggstatus_{$key}').innerHTML = '서버점검중';
+							else jQuery("#ggsend_{$key}").show();
+						},
+						global: false,
+						cache: false,
+						contentType: false,
+						processData: false
+					});
+					return false;
+				})
+			</script>
 			<td width="60" class="center">
-				<!--@if($authcheck->is_sendok == 'Y')-->{$lang->send_complete}
-				<!--@elseif($authcheck->is_sendok == 'W')-->통신대기
-				<!--@elseif($authcheck->is_sendok == 'S')-->전송중
-				<!--@elseif($authcheck->is_sendok == 'E')-->오류
-				<!--@elseif(!$authcheck)-->서버점검중
+				<div id="ggstatus_{$key}"></div>
+				<!--@if(Context::get('type')!='status')-->
+				<form action="./" method="post" id="ggsend_{$key}" style="display:none;">
+				<input type="hidden" name="module" value="admin" />
+				<input type="hidden" name="act" value="procGgmailingAdminSendOk" />
+				<input type="hidden" name="ggmailing_send_srl" value="{$val->ggmailing_send_srl}" />
+				<input type="hidden" name="page" value="{$page}" />
+				<input type="submit" class="xet_btn medium light" value="{$lang->send_start}" />
+				</form>
 				<!--@else-->
-					<!--@if(Context::get('type')!='status')-->
-					<form action="./" method="post">
-					<input type="hidden" name="module" value="admin" />
-					<input type="hidden" name="act" value="procGgmailingAdminSendOk" />
-					<input type="hidden" name="ggmailing_send_srl" value="{$val->ggmailing_send_srl}" />
-					<input type="hidden" name="page" value="{$page}" />
-					<input type="submit" class="xet_btn medium light" value="{$lang->send_start}" />
-					</form>
-					<!--@else-->
-					전송안됨
-					<!--@end-->
+				전송안됨
 				<!--@end-->
 			</td>
 			


### PR DESCRIPTION
- 메일 전송시 비동기로 소켓전송하도록 변경 cURL -> Socket
- 대시보드 노출되는 포인트, 대기열, 공지목록 등을 ajax 비동기 처리하여 속도를 높였다.
- 댓글알림 기능을 추가하기 위하여 댓글 트리거를 추가하였고, 기존의 게시판 메일링 관리 화면에서 함께 관리할 수 있도록 document_srl 을 목록을 추가하였다.
- 수신자 거부 관리 기능 추가
- 게시판 메일링 / 댓글알림 / 알림센터 연동 기능 코드 최적화 및 비동기 통신 시스템 변경
- 뉴스레터 중복 이메일 체크시 이용하기 위하여 이메일도 체크할 수 있도록 수정
- 뉴스레터 기능 구현 및 설정 추가
- 뉴스레터/게시판메일링/와드 트리거 작동시 mid 등록 해야만 작동하도록 수정, 다시말해 등록되지 않은 게시판에서는 트리거 작동 안하도록 수정
